### PR TITLE
Add Nintendo Switch 2 hardware reference entries

### DIFF
--- a/backend/alembic/versions/07b6adcc2380_seed_nintendo_switch_2_hardware_entries.py
+++ b/backend/alembic/versions/07b6adcc2380_seed_nintendo_switch_2_hardware_entries.py
@@ -1,0 +1,47 @@
+"""seed nintendo switch 2 hardware reference entries
+
+Revision ID: 07b6adcc2380
+Revises: 56b03c3c66b8
+Create Date: 2026-07-21 12:23:19.013436
+
+Nintendo Switch 2 launched (2025) after the curated dataset baked into 56b03c3c66b8 was
+generated, so the console and its launch accessories are missing from
+hardware_reference_entries. This leaves it out of the Brand/Console/Variant cascade on
+Add Device/Add Accessory. Same `INSERT OR IGNORE` approach keyed off the unique
+`official_name` index so it's safe to re-run against a DB that already has these rows.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import json as _json
+
+
+# revision identifiers, used by Alembic.
+revision: str = "07b6adcc2380"
+down_revision: Union[str, None] = "56b03c3c66b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ENTRIES_JSON = r'''[{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Nintendo Switch 2","official_name":"Nintendo Switch 2","category":"Console","type":"Device","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Nintendo Switch 2 is an official Nintendo gaming system that introduced new hardware capabilities and a library of first-party and third-party titles. It remains an important part of Nintendo's gaming history."},{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Joy-Con 2 (L)","official_name":"Nintendo Joy-Con 2 (Left)","category":"Controller","type":"Accessory","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Joy-Con 2 (L) is an official Nintendo accessory designed to provide left-hand controls. It extends the functionality of compatible Nintendo hardware while integrating seamlessly with the Nintendo ecosystem."},{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Joy-Con 2 (R)","official_name":"Nintendo Joy-Con 2 (Right)","category":"Controller","type":"Accessory","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Joy-Con 2 (R) is an official Nintendo accessory designed to provide right-hand controls. It extends the functionality of compatible Nintendo hardware while integrating seamlessly with the Nintendo ecosystem."},{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Joy-Con 2 Charging Grip","official_name":"Nintendo Joy-Con 2 Charging Grip","category":"Charging","type":"Accessory","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Joy-Con 2 Charging Grip is an official Nintendo accessory designed to charge Joy-Con 2 controllers while playing. It extends the functionality of compatible Nintendo hardware while integrating seamlessly with the Nintendo ecosystem."},{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Nintendo Switch 2 Pro Controller","official_name":"Nintendo Switch 2 Pro Controller","category":"Controller","type":"Accessory","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Nintendo Switch 2 Pro Controller is an official Nintendo accessory designed to provide premium wireless gameplay. It extends the functionality of compatible Nintendo hardware while integrating seamlessly with the Nintendo ecosystem."},{"brand":"Nintendo","family":"Nintendo","generation":"Nintendo Switch 2","generation_short":null,"artefact":"Nintendo Switch 2 Camera","official_name":"Nintendo Switch 2 Camera","category":"Camera","type":"Accessory","release_date":"2025","discontinued":0,"compatibility":"Nintendo Switch 2","summary":"The Nintendo Switch 2 Camera is an official Nintendo accessory designed to enable GameChat video calls. It extends the functionality of compatible Nintendo hardware while integrating seamlessly with the Nintendo ecosystem."}]'''
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    entries = _json.loads(_ENTRIES_JSON)
+    bind.execute(
+        sa.text(
+            "INSERT OR IGNORE INTO hardware_reference_entries "
+            "(brand, family, generation, generation_short, artefact, official_name, "
+            "category, type, release_date, discontinued, compatibility, summary) "
+            "VALUES (:brand, :family, :generation, :generation_short, :artefact, :official_name, "
+            ":category, :type, :release_date, :discontinued, :compatibility, :summary)"
+        ),
+        entries,
+    )
+
+
+def downgrade() -> None:
+    # Not reversed — Device/Accessory rows may already reference these entries by FK.
+    pass


### PR DESCRIPTION
## Summary
- Nintendo Switch 2 isn't in the Brand/Console/Variant cascade on Add Device / Add Accessory — only the original Switch is.
- Adds Alembic migration `07b6adcc2380` (on top of head `56b03c3c66b8`) seeding `hardware_reference_entries` with the Switch 2 console and launch accessories, following the same curated-dataset pattern used for the rest of the Nintendo lineup.

## Entries added
- Nintendo Switch 2 (Console / Device)
- Joy-Con 2 (Left)
- Joy-Con 2 (Right)
- Joy-Con 2 Charging Grip
- Nintendo Switch 2 Pro Controller
- Nintendo Switch 2 Camera

All tagged with `generation`/`compatibility` = "Nintendo Switch 2" (brand "Nintendo"), matching the shape of the existing Switch/Switch Lite/Switch OLED rows. Insert uses `INSERT OR IGNORE` keyed off the unique `official_name` index, so it's idempotent against a DB that already has some of this data. `downgrade()` is a no-op, same rationale as `56b03c3c66b8` — Device/Accessory rows may already FK into these entries.

## Test plan
- [ ] `alembic upgrade head` runs clean
- [ ] `hardware_reference_entries` table has the 6 new rows
- [ ] Add Device / Add Accessory form shows "Nintendo Switch 2" in the Console dropdown with its accessories cascading correctly