### PR TITLE
fix parsing blank DATABASE_URL in .env, which breaks "alembic upgrade head"

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,7 +17,7 @@ HARDWARE_REFERENCE_IMAGES_DIR = BACKEND_DIR / "static" / "hardware-reference"
 class Settings(BaseSettings):
     # Secrets live in one .env at the repo root (not backend/), so the same file works for
     # both local dev and the Docker Compose setup, which reads it from there too.
-    model_config = SettingsConfigDict(env_file=str(REPO_ROOT / ".env"), extra="ignore")
+    model_config = SettingsConfigDict(env_file=str(REPO_ROOT / ".env"), extra="ignore", env_ignore_empty=True)
 
     app_name: str = "VideoGameTrackarr API"
     environment: str = "development"


### PR DESCRIPTION
The example env file states that the DATABASE_URL is optional. But when setting up the db per the readme an error occurs. Specifically when running  `alembic upgrade head`:

> sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from given URL string

The fix is to ignore empty env variable values, instead of parsing them as '' (blank). 

See: [https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/#parsing-environment-variable-values](https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/#parsing-environment-variable-values)